### PR TITLE
Python 2/3-compatible code for handling unicode paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Gallery Plugins:
 * imgbox
 * imagevenue
 * imagefap
+* gfycat
 * xHamster
 
 Generic Plugin works for:

--- a/gallery_get.py
+++ b/gallery_get.py
@@ -47,7 +47,13 @@ try:
 except:
     str_type = str
 
-
+# Python 2/3 compatibility
+def unicode_safe(str):
+    try:
+        str = str.decode("utf8")
+    except:
+        pass
+    return str
 
 # some galleries reject requests if they're not coming from a browser- this is to get past that.
 class BrowserFaker(urllib.FancyURLopener):
@@ -62,10 +68,7 @@ MAX_ATTEMPTS = 10
 PLUGIN = gallery_plugins.PLUGINS["plugin_generic"]
 TEXTCHARS = ''.join(map(chr, [7,8,9,10,12,13,27] + list(range(0x20, 0x100))))
 DESTPATH_FILE = os.path.join(os.path.dirname(str(__file__)), "last_gallery_dest.txt")
-try:
-    DEST_ROOT = os.getcwd().decode("utf8")
-except:
-    DEST_ROOT = os.getcwd()
+DEST_ROOT = unicode_safe(os.getcwd())
 
 EXCEPTION_NOTICE = """An exception occurred!  We can help if you follow these steps:\n
 1. Visit https://github.com/regosen/gallery_get/issues
@@ -88,6 +91,7 @@ def safestr(name):
 
 def is_str(obj):
     return isinstance(obj, str_type)
+
 
 def safe_unpack(obj, default):
     if is_str(obj):
@@ -377,11 +381,7 @@ def run_wrapped(myurl, dest, titleAsFolder=False, cacheDest=True, flushJobs=True
                 safeCacheDestination(dest)
             elif os.path.exists(DESTPATH_FILE):
                 dest = open(DESTPATH_FILE,"r").read().strip()
-            try:
-                DEST_ROOT = dest.decode("utf8")
-                dest = dest.decode("utf8")
-            except:
-                DEST_ROOT = dest
+            DEST_ROOT = unicode_safe(dest)
         run_internal(myurl, dest, titleAsFolder)
         if flushJobs:
             flush_jobs()
@@ -397,10 +397,6 @@ def run_wrapped(myurl, dest, titleAsFolder=False, cacheDest=True, flushJobs=True
 def run_prompted():
     global DEST_ROOT
     myurl = str_input("Input URL: ").strip()
-    try:
-        DEST_ROOT = DEST_ROOT.encode("utf8")
-    except:
-        pass
     new_dest = str_input("Destination (%s): " % DEST_ROOT).strip()
     if new_dest:
         run_wrapped(myurl, new_dest)
@@ -422,17 +418,14 @@ def safeCacheDestination(dest):
 cur_file = os.path.basename(str(__file__))
 arg_file = sys.argv[0]
 if os.path.exists(DESTPATH_FILE):
-    DEST_ROOT = open(DESTPATH_FILE,"r").read().strip()
+    DEST_ROOT = unicode_safe(open(DESTPATH_FILE,"r").read().strip())
 
 if arg_file and os.path.basename(arg_file) == cur_file:
     ### DIRECT LAUNCH (not import)
     if len(sys.argv) > 1:
         # use first parameter as url, second (if exists) as dest
         if len(sys.argv) > 2:
-            try:
-                DEST_ROOT = sys.argv[2].decode("utf8")
-            except:
-                DEST_ROOT = sys.argv[2]
+            DEST_ROOT = unicode_safe(sys.argv[2])
             safeCacheDestination(DEST_ROOT)
         run_wrapped(sys.argv[1], DEST_ROOT)
     else:

--- a/gallery_get.py
+++ b/gallery_get.py
@@ -17,6 +17,7 @@
 
 import os,time,sys,traceback
 import re
+import io
 try:
     import urllib.request as urllib
 except:
@@ -62,7 +63,7 @@ MAX_ATTEMPTS = 10
 PLUGIN = gallery_plugins.PLUGINS["plugin_generic"]
 TEXTCHARS = ''.join(map(chr, [7,8,9,10,12,13,27] + list(range(0x20, 0x100))))
 DESTPATH_FILE = os.path.join(os.path.dirname(str(__file__)), "last_gallery_dest.txt")
-DEST_ROOT = os.getcwd()
+DEST_ROOT = os.getcwd().decode("utf8")
 
 EXCEPTION_NOTICE = """An exception occurred!  We can help if you follow these steps:\n
 1. Visit https://github.com/regosen/gallery_get/issues
@@ -373,7 +374,7 @@ def run_wrapped(myurl, dest, titleAsFolder=False, cacheDest=True, flushJobs=True
             if dest:
                 safeCacheDestination(dest)
             elif os.path.exists(DESTPATH_FILE):
-                dest = open(DESTPATH_FILE,"r").read().strip()
+                dest = io.open(DESTPATH_FILE,"r").read().strip()
             DEST_ROOT = dest
         run_internal(myurl, dest, titleAsFolder)
         if flushJobs:
@@ -390,7 +391,7 @@ def run_wrapped(myurl, dest, titleAsFolder=False, cacheDest=True, flushJobs=True
 def run_prompted():
     global DEST_ROOT
     myurl = str_input("Input URL: ").strip()
-    new_dest = str_input("Destination (%s): " % DEST_ROOT).strip()
+    new_dest = str_input("Destination (%s): " % DEST_ROOT.encode("utf8")).strip()
     if new_dest:
         run_wrapped(myurl, new_dest)
     else:
@@ -412,14 +413,14 @@ def safeCacheDestination(dest):
 cur_file = os.path.basename(str(__file__))
 arg_file = sys.argv[0]
 if os.path.exists(DESTPATH_FILE):
-    DEST_ROOT = open(DESTPATH_FILE,"r").read().strip()
+    DEST_ROOT = io.open(DESTPATH_FILE,"r").read().strip()
     
 if arg_file and os.path.basename(arg_file) == cur_file:
     ### DIRECT LAUNCH (not import)
     if len(sys.argv) > 1:
         # use first parameter as url, second (if exists) as dest
         if len(sys.argv) > 2:
-            DEST_ROOT = sys.argv[2]
+            DEST_ROOT = sys.argv[2].decode("utf8")
             safeCacheDestination(DEST_ROOT)
         run_wrapped(sys.argv[1], DEST_ROOT)
     else:

--- a/gallery_plugins/plugin_gfycat.py
+++ b/gallery_plugins/plugin_gfycat.py
@@ -9,9 +9,7 @@ def title(source):
     link = 'https://gfycat.com/cajax/get/' + gfyId
     respond = urllib.urlopen(link).read()
     username = re.findall(r'\"userName\":\"(.+?)\",' ,respond)[0]
-    if username == "anonymous":
-        username = "gfycat" + gfyId
-    return username
+    return username if username != "anonymous" else "gfycat " + gfyId
 
 def redirect(source):
     gfyId = re.findall(r'href=\".*gfycat.com/(\w+).*\">', source)[-1]

--- a/gallery_plugins/plugin_gfycat.py
+++ b/gallery_plugins/plugin_gfycat.py
@@ -1,0 +1,25 @@
+import re
+try:
+    import urllib.request as urllib
+except:
+    import urllib # Python 2
+
+def title(source):
+    gfyId = re.findall(r'href=\".*gfycat.com/(\w+).*\">', source)[-1]
+    link = 'https://gfycat.com/cajax/get/' + gfyId
+    respond = urllib.urlopen(link).read()
+    username = re.findall(r'\"userName\":\"(.+?)\",' ,respond)[0]
+    if username == "anonymous":
+        username = "gfycat" + gfyId
+    return username
+
+def redirect(source):
+    gfyId = re.findall(r'href=\".*gfycat.com/(\w+).*\">', source)[-1]
+    respond = urllib.urlopen('https://gfycat.com/cajax/get/' + gfyId).read()
+    webmurl = re.findall(r'\"webmUrl\":\"(.+?)\",' ,respond)[0]
+    # delete escape characters
+    webmurl = webmurl.replace("\\","")
+    # for some reason we can not connect via https
+    webmurl = webmurl.replace("https", "http")
+    return webmurl
+same_filename = True

--- a/reddit_get.py
+++ b/reddit_get.py
@@ -66,21 +66,21 @@ def run_internal(user, dest):
         num_valid_posts = 0
         for post in reddit_json['data']['children']:
             url = post['data']['url']
-                
+
             if url.lower() in visited_links:
                 print("Skipping already visited link: " + url)
                 continue
             else:
                 visited_links.add(url.lower())
-                
+
             cdate = post['data']['created']
             sdate = datetime.datetime.fromtimestamp(cdate).strftime("%Y-%m-%d")
             title = post['data']['title'].replace('/', '_').replace('\\', '_').strip()
             if title:
                 title = " - " + title
-                
+
             folder = os.path.join(dest, user, gallery_get.safestr(sdate + title))
-            
+
             if "/i.imgur.com/" in url:
                 download_image(url, folder)
             elif "/imgur.com/a/" in url:
@@ -97,7 +97,7 @@ def run_internal(user, dest):
                 if real_ext != "jpeg": # jpeg -> jpg
                     ext = real_ext
                 download_image("%s.%s" % (img_base, ext), folder)
-            elif "gfycat.com" in url:
+            elif "/gfycat.com/" in url:
                 if not gallery_get.run_wrapped(url, folder, titleAsFolder=True, cacheDest=False, flushJobs=False):
                     return False
             elif "vidble.com/album" in url:

--- a/reddit_get.py
+++ b/reddit_get.py
@@ -97,6 +97,9 @@ def run_internal(user, dest):
                 if real_ext != "jpeg": # jpeg -> jpg
                     ext = real_ext
                 download_image("%s.%s" % (img_base, ext), folder)
+            elif "gfycat.com" in url:
+                if not gallery_get.run_wrapped(url, folder, titleAsFolder=True, cacheDest=False, flushJobs=False):
+                    return False
             elif "vidble.com/album" in url:
                 if not gallery_get.run_wrapped(url, folder, titleAsFolder=True, cacheDest=False, flushJobs=False):
                     return False


### PR DESCRIPTION
Hi @talha252 , I cleaned up the compatibility code a little.  Let me know if it still works for you!

By the way, the gfycat plugin itself is broken in Python 3 as well.  I didn't have time to investigate that yet, care to take a look?

```
Traceback (most recent call last):
  File "gallery_get.py", line 385, in run_wrapped
    run_internal(myurl, dest, titleAsFolder)
  File "gallery_get.py", line 319, in run_internal
    title = run_match(PLUGIN.title, page, True)
  File "gallery_get.py", line 121, in run_match
    result = match(source)
  File "/Users/regosen/Projects/Scripts/gallery_get/gallery_plugins/plugin_gfycat.py", line 11, in title
    username = re.findall(r'\"userName\":\"(.+?)\",' ,respond)[0]
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/re.py", line 213, in findall
    return _compile(pattern, flags).findall(string)
TypeError: cannot use a string pattern on a bytes-like object
Using params: ['https://gfycat.com/AlertCloudyIceblueredtopzebra', '/Users/regosen/Pictures', False]
```