### PR TITLE
Matching plugins against URL rather than URL in page content.

### DIFF
--- a/gallery_get.py
+++ b/gallery_get.py
@@ -427,7 +427,7 @@ class GalleryGet(object):
             return False
 
         ### FIND MATCHING PLUGIN
-        plugin = self.match_plugin(page)
+        plugin = self.match_plugin(self.url)
         if plugin == None:
             print("Couldn't access gallery page! Try saving page(s) locally and use local path instead.")
             return False


### PR DESCRIPTION
Something I noticed is that sometimes gallery_get attempts to use the wrong plugin because it finds a url within the page content that doesn't actually belong to the site.  A quick fix for this would be to determine the plugin based on the URL of the gallery to download.