### PR TITLE
Fixed change of domain name for imagefap full size images.

### DIFF
--- a/gallery_plugins/plugin_imagefap.py
+++ b/gallery_plugins/plugin_imagefap.py
@@ -31,7 +31,7 @@ def redirect(source):
     return redirects
 
 # direct_links: if redirect is non-empty, this parses each redirect page for a single image.  Otherwise, this parses the gallery page for all images.
-direct_links = r'name="mainPhoto".+?(https?://x.imagefapusercontent.com/.+?\.(jpe?g?|png|gif))'
+direct_links = r'name=\"mainPhoto\".*?(https?://.*?\.imagefap.*?\.com/.*?\.(jpe?g?|png|gif).*?)\"'
 
-# same_filename (default=False): if True, uses filename specified on remote link.  Otherwise, creates own filename with incremental index. 
+# same_filename (default=False): if True, uses filename specified on remote link.  Otherwise, creates own filename with incremental index.
 same_filename = True


### PR DESCRIPTION
It looks like imagefap changed their domain name for where they host full size images.  This update to the regex fixes that.